### PR TITLE
Fix the misplaced symbols about interval fallback.

### DIFF
--- a/wait.php
+++ b/wait.php
@@ -111,7 +111,7 @@ const INTERVAL = 'INPUT_CHECKINTERVAL';
                     }
 
                     if ($state === 'pending') {
-                        $interval = getenv(INTERVAL) === null ? getenv(INTERVAL) : 10;
+                        $interval = getenv(INTERVAL) === null ? 10 : getenv(INTERVAL);
                         $logger->warning('Checks are pending, checking again in ' . $interval . ' seconds');
                         timedPromise($loop, $interval)->then(function () use ($commit, $checkChecks, $logger) {
                             $logger->notice('Checking statuses');


### PR DESCRIPTION
I always get the default interval 10 even if I set 13 in the version 0.1.0. But it does not happen in the commit f8bbe3bb321919ec6a009bc98121f39874dc8ee0.
This should be the reason I think.