### PR TITLE
Add `ignoreContexts` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ List of actions to ignore the status from, mainly to exclude the action this act
 * *Type*: `CSV`
 * *Example*: `automerge,otheraction` but a single action is also perfectly valid `automerge`
 
+### ignoreContexts
+
+List of contexts to ignore the status from, mainly to exclude external checks.
+
+* *Required*: `No`
+* *Type*: `CSV`
+* *Example*: `coverage/coveralls,ci/circleci: build` but a single action is also perfectly valid `coverage/coveralls`
+
 ### checkInterval
 
 The amount of seconds to wait between checks, adjust depending on the expected time all the checks and related CI's will take.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
   ignoreActions:
     description: 'CSV of action names to ignore'
     required: true
+  ignoreContexts:
+    description: 'CSV of status contexts to ignore'
+    required: false
+    default: ''
   checkInterval:
     description: 'Time between checks (in seconds)'
     required: false

--- a/src/App.php
+++ b/src/App.php
@@ -46,7 +46,7 @@ final class App
         $this->github = $github;
     }
 
-    public function wait(string $repository, string $ignoreActions, float $checkInterval, string ...$shas): PromiseInterface
+    public function wait(string $repository, string $ignoreActions, string $ignoreContexts, float $checkInterval, string ...$shas): PromiseInterface
     {
         $timer = $this->rateLimitTimer();
         /**
@@ -62,7 +62,7 @@ final class App
         return unwrapObservableFromPromise((new LookUpRepository($repository, $this->logger))($this->github)->then(
             new LookUpCommits($this->logger, ...$shas)
         ))->flatMap(
-            new GetStatusChecksFromCommits($this->loop, $this->logger, $ignoreActions, $checkInterval)
+            new GetStatusChecksFromCommits($this->loop, $this->logger, $ignoreActions, $ignoreContexts, $checkInterval)
         )->map(
             new WaitForStatusCheckResult($this->loop, $this->logger, $checkInterval)
         )->toArray()->toPromise()->then(static function (array $promises): PromiseInterface {

--- a/src/GetStatusChecksFromCommits.php
+++ b/src/GetStatusChecksFromCommits.php
@@ -20,14 +20,16 @@ final class GetStatusChecksFromCommits
     private LoopInterface $loop;
     private LoggerInterface $logger;
     private string $ignoreActions;
+    private string $ignoreContexts;
     private float $checkInterval;
 
-    public function __construct(LoopInterface $loop, LoggerInterface $logger, string $ignoreActions, float $checkInterval)
+    public function __construct(LoopInterface $loop, LoggerInterface $logger, string $ignoreActions, string $ignoreContexts, float $checkInterval)
     {
-        $this->loop          = $loop;
-        $this->logger        = $logger;
-        $this->ignoreActions = $ignoreActions;
-        $this->checkInterval = $checkInterval;
+        $this->loop           = $loop;
+        $this->logger         = $logger;
+        $this->ignoreActions  = $ignoreActions;
+        $this->ignoreContexts = $ignoreContexts;
+        $this->checkInterval  = $checkInterval;
     }
 
     public function __invoke(Commit $commit): Observable
@@ -41,9 +43,7 @@ final class GetStatusChecksFromCommits
             })->then(function (Commit $commit): PromiseInterface {
                 return all([
                     'checks' => new Checks($commit, $this->logger, $this->ignoreActions),
-                    'status' => $commit->status()->then(function (Commit\CombinedStatus $combinedStatus): StatusCheckInterface {
-                        return new Status($this->logger, $combinedStatus);
-                    }),
+                    'status' => new Status($commit, $this->logger, $this->ignoreContexts),
                 ]);
             })->then(static function (array $statusChecks): PromiseInterface {
                 return resolve(observableFromArray($statusChecks));

--- a/wait.php
+++ b/wait.php
@@ -18,6 +18,7 @@ const SHA = 'GITHUB_SHA';
 const EVENT = 'GITHUB_EVENT_NAME';
 const EVENT_PATH = 'GITHUB_EVENT_PATH';
 const ACTIONS = 'INPUT_IGNOREACTIONS';
+const CONTEXTS = 'INPUT_IGNORECONTEXTS';
 const INTERVAL = 'INPUT_CHECKINTERVAL';
 
 (function () {
@@ -41,6 +42,7 @@ const INTERVAL = 'INPUT_CHECKINTERVAL';
     App::boot($loop, $logger, new Token(getenv(TOKEN)))->wait(
         getenv(REPOSITORY),
         getenv(ACTIONS),
+        getenv(CONTEXTS),
         (float) getenv(INTERVAL) > 0.0 ? (float) getenv(INTERVAL) : 13,
         ...$shas,
     )->then(function (string $state) use($logger) {


### PR DESCRIPTION
This adds the `ignoreContexts` option, so external checks can be excluded as well.

I've pretty much copied the code for Checks, and replaced `->name()` with `->context()` and `->status()` with `->state()`.

PS: I haven't written PHP in a decade, so I don't what current idiomatic code looks like nowadays. Feel free to nitpick :)