### PR TITLE
feat: neutral checks should not count as a failure

### DIFF
--- a/src/StatusCheck/Checks.php
+++ b/src/StatusCheck/Checks.php
@@ -50,7 +50,7 @@ final class Checks implements StatusCheckInterface
                     $return = TRUE_;
                 }
 
-                if ($status->status() !== 'completed' || $status->conclusion() === 'success' || $status->conclusion() === 'skipped') {
+                if ($status->status() !== 'completed' || $status->conclusion() === 'success' || $status->conclusion() === 'skipped' || $status->conclusion() === 'neutral') {
                     continue;
                 }
 


### PR DESCRIPTION
Hey there!

We're trying this out in conjunction with the Cloud Build GitHub App, which may return a `neutral` status if the files in the PR didn't match any of the triggers for the build. This is similar to `skipped`, and counts as a success from the perspective of required checks (e.g. https://github.community/t/does-a-neutral-check-run-conclusion-satisfy-a-required-check/13706).

I believe this line is what is causing it to be interpreted as a failure, so I've added an additional conditional to account for `neutral.`

Feel free to make any changes you see fit. Thanks!