### PR TITLE
Add support for waiting for the first check to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GitHub Action that waits for successful commit statuses and checks.
 
 ![](images/action.png)
 
-This actions main goal is to wait until all statuses and checks are successful or any of them has failed and set its 
+This actions main goal is to wait until all statuses and checks are successful or any of them has failed and set its
 status output accordingly.
 
 ## Options
@@ -28,6 +28,15 @@ The amount of seconds to wait between checks, adjust depending on the expected t
 * *Default*: `10`
 * *Example*: `60` for longer running jobs, or `5` for very short jobs.
 
+### waitForCheck
+
+If true, this option will first wait for at least one check to be added to a commit. This is useful for external CIs that take some time to calculate which jobs need to be completed.
+
+* *Required*: `No`
+* *Type*: `true` or `""`
+* *Default*: `""`
+* *Example*: `true`
+
 ## Output
 
 This action has only one output and that's the `status` output. It has two possible values:
@@ -39,12 +48,12 @@ This action has only one output and that's the `status` output. It has two possi
 
 As shown in the example below the `status` output can be used to skip any follow up steps in the action if conditions aren't met.
 
-*Note*, that this action always has exit code `0` unless something fails, that's because it's indifferent about your 
+*Note*, that this action always has exit code `0` unless something fails, that's because it's indifferent about your
 state of your statuses and checks and leave what to do up to you.
 
 ## Example
 
-The following example is taken from the `PHP` package [`wyrihaximus/fake-php-version`](https://github.com/wyrihaximus/php-fake-php-version/)  
+The following example is taken from the `PHP` package [`wyrihaximus/fake-php-version`](https://github.com/wyrihaximus/php-fake-php-version/)
 where any PR with the `automerge` label will be automatically merged using [`pascalgn/automerge-action`](https://github.com/marketplace/actions/merge-pull-requests).
 The output of an action can be seen [here](https://github.com/WyriHaximus/php-fake-php-version/commit/0de3b06ee111ccc8b600219b95cebe4b434bef63/checks?check_suite_id=263513218).
 But in order to ensure we don't merge a failing PR we use this action to ensure everything is green before merging it.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Time between checks (in seconds)'
     required: false
     default: 10
+  waitForCheck:
+    description: 'Whether to wait for a check if none are present'
+    required: false
+    default: ""
 outputs:
   status:
     description: 'Success or failure'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="2"
+    reportMixedIssues="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/App.php
+++ b/src/App.php
@@ -47,7 +47,7 @@ final class App
         $this->github = $github;
     }
 
-    public function wait(string $repository, string $ignoreActions, float $checkInterval, string ...$shas): PromiseInterface
+    public function wait(string $repository, string $ignoreActions, float $checkInterval, bool $waitForCheck, string ...$shas): PromiseInterface
     {
         $timer = $this->rateLimitTimer();
         /**
@@ -63,7 +63,7 @@ final class App
         return unwrapObservableFromPromise((new LookUpRepository($repository, $this->logger))($this->github)->then(
             new LookUpCommits($this->logger, ...$shas)
         ))->flatMap(
-            new GetStatusChecksFromCommits(Loop::get(), $this->logger, $ignoreActions, $checkInterval)
+            new GetStatusChecksFromCommits(Loop::get(), $this->logger, $ignoreActions, $checkInterval, $waitForCheck)
         )->map(
             new WaitForStatusCheckResult(Loop::get(), $this->logger, $checkInterval)
         )->toArray()->toPromise()->then(static function (array $promises): PromiseInterface {

--- a/src/GetStatusChecksFromCommits.php
+++ b/src/GetStatusChecksFromCommits.php
@@ -24,13 +24,15 @@ final class GetStatusChecksFromCommits
     private LoggerInterface $logger;
     private string $ignoreActions;
     private float $checkInterval;
+    private bool $waitForCheck;
 
-    public function __construct(LoopInterface $loop, LoggerInterface $logger, string $ignoreActions, float $checkInterval)
+    public function __construct(LoopInterface $loop, LoggerInterface $logger, string $ignoreActions, float $checkInterval, bool $waitForCheck)
     {
         $this->loop          = $loop;
         $this->logger        = $logger;
         $this->ignoreActions = $ignoreActions;
         $this->checkInterval = $checkInterval;
+        $this->waitForCheck  = $waitForCheck;
     }
 
     public function __invoke(Commit $commit): Observable
@@ -45,7 +47,7 @@ final class GetStatusChecksFromCommits
                 return all([
                     'checks' => new Checks($commit, $this->logger, $this->ignoreActions),
                     'status' => $commit->status()->then(function (Commit\CombinedStatus $combinedStatus): StatusCheckInterface {
-                        return new Status($this->logger, $combinedStatus);
+                        return new Status($this->logger, $combinedStatus, $this->waitForCheck);
                     }),
                 ]);
             })->then(static function (array $statusChecks): PromiseInterface {

--- a/src/StatusCheck/Status.php
+++ b/src/StatusCheck/Status.php
@@ -18,19 +18,27 @@ final class Status implements StatusCheckInterface
 {
     private LoggerInterface $logger;
     private Commit\CombinedStatus $combinedStatus;
-    private bool $resolved   = FALSE_;
-    private bool $successful = FALSE_;
+    private bool $resolved     = FALSE_;
+    private bool $successful   = FALSE_;
+    private bool $waitForCheck = FALSE_;
 
-    public function __construct(LoggerInterface $logger, Commit\CombinedStatus $combinedStatus)
+    public function __construct(LoggerInterface $logger, Commit\CombinedStatus $combinedStatus, bool $waitForCheck)
     {
         $this->logger         = $logger;
         $this->combinedStatus = $combinedStatus;
+        $this->waitForCheck   = $waitForCheck;
     }
 
     public function refresh(): PromiseInterface
     {
         return $this->combinedStatus->refresh()->then(function (Commit\CombinedStatus $status): PromiseInterface {
             if ($status->totalCount() === 0) {
+                if ($this->waitForCheck) {
+                    $this->logger->warning('No statuses found yet, waiting');
+
+                    return resolve();
+                }
+
                 $this->logger->warning('No statuses found, assuming success');
                 $this->resolved   = TRUE_;
                 $this->successful = TRUE_;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -37,6 +37,7 @@ final class AppTest extends AsyncTestCase
                 'WyriHaximus/github-action-wait-for-status',
                 'wait',
                 1,
+                false,
                 'd2ddfe536405fa61cd5f8ae1b3e06f192bac1d64'
             ),
             30
@@ -65,6 +66,7 @@ final class AppTest extends AsyncTestCase
                 'WyriHaximus/php-broadcast',
                 'wait',
                 1,
+                false,
                 '67bdf304b34567e0f434bc0f9f19d3022cc1aa6c'
             ),
             30
@@ -92,6 +94,7 @@ final class AppTest extends AsyncTestCase
                 'WyriHaximus/github-action-wait-for-status',
                 'wait',
                 1,
+                false,
                 'd2ddfe536405fa61cd5f8ae1b3e06f192bac1d64'
             ),
             30

--- a/tests/GetStatusChecksFromCommitsTest.php
+++ b/tests/GetStatusChecksFromCommitsTest.php
@@ -60,7 +60,7 @@ final class GetStatusChecksFromCommitsTest extends AsyncTestCase
         $this->commit->sha()->shouldBeCalled()->willReturn(self::SHA);
         $this->commit->refresh()->shouldBeCalled()->willReturn(resolve($commit));
         $this->commit->status()->shouldBeCalled()->willReturn(resolve($combinedStatus));
-        $promise = (new GetStatusChecksFromCommits($loop, $logger, self::IGNORE_ACTIONS, 0.1))($commit)->toArray()->toPromise();
+        $promise = (new GetStatusChecksFromCommits($loop, $logger, self::IGNORE_ACTIONS, 0.1, false))($commit)->toArray()->toPromise();
         $result  = $this->await($promise);
         self::assertInstanceOf(Checks::class, $result[0]);
         self::assertInstanceOf(Status::class, $result[1]);

--- a/tests/StatusCheck/StatusTest.php
+++ b/tests/StatusCheck/StatusTest.php
@@ -39,7 +39,7 @@ final class StatusTest extends AsyncTestCase
         $this->combinedStatus->totalCount()->shouldBeCalled()->willReturn(1);
         $this->combinedStatus->state()->shouldBeCalled()->willReturn('success');
         $this->combinedStatus->refresh()->shouldBeCalled()->willReturn(resolve($combinedStatus));
-        $status = new Status($logger, $combinedStatus);
+        $status = new Status($logger, $combinedStatus, false);
         self::assertFalse($status->hasResolved());
         self::assertFalse($status->isSuccessful());
         $status->refresh();
@@ -59,7 +59,7 @@ final class StatusTest extends AsyncTestCase
         $this->combinedStatus->totalCount()->shouldBeCalled()->willReturn(1);
         $this->combinedStatus->state()->shouldBeCalled()->willReturn('failure');
         $this->combinedStatus->refresh()->shouldBeCalled()->willReturn(resolve($combinedStatus));
-        $status = new Status($logger, $combinedStatus);
+        $status = new Status($logger, $combinedStatus, false);
         self::assertFalse($status->hasResolved());
         self::assertFalse($status->isSuccessful());
         $status->refresh();
@@ -80,7 +80,7 @@ final class StatusTest extends AsyncTestCase
         $this->combinedStatus->totalCount()->shouldBeCalled()->willReturn(1);
         $this->combinedStatus->state()->shouldBeCalled()->willReturn('pending');
         $this->combinedStatus->refresh()->shouldBeCalled()->willReturn(resolve($combinedStatus));
-        $status = new Status($logger, $combinedStatus);
+        $status = new Status($logger, $combinedStatus, false);
         self::assertFalse($status->hasResolved());
         self::assertFalse($status->isSuccessful());
         $status->refresh();
@@ -100,7 +100,7 @@ final class StatusTest extends AsyncTestCase
         assert($combinedStatus instanceof Commit\CombinedStatus);
         $this->combinedStatus->totalCount()->shouldBeCalled()->willReturn(0);
         $this->combinedStatus->refresh()->shouldBeCalled()->willReturn(resolve($combinedStatus));
-        $status = new Status($logger, $combinedStatus);
+        $status = new Status($logger, $combinedStatus, false);
         self::assertFalse($status->hasResolved());
         self::assertFalse($status->isSuccessful());
         $status->refresh();

--- a/wait.php
+++ b/wait.php
@@ -19,6 +19,7 @@ const EVENT = 'GITHUB_EVENT_NAME';
 const EVENT_PATH = 'GITHUB_EVENT_PATH';
 const ACTIONS = 'INPUT_IGNOREACTIONS';
 const INTERVAL = 'INPUT_CHECKINTERVAL';
+const WAIT_FOR_CHECK = 'INPUT_WAITFORCHECK';
 
 (function () {
     $consoleHandler = new FormattedPsrHandler(StdioLogger::create(Loop::get())->withHideLevel(true));
@@ -41,6 +42,7 @@ const INTERVAL = 'INPUT_CHECKINTERVAL';
         getenv(REPOSITORY),
         getenv(ACTIONS),
         (float) getenv(INTERVAL) > 0.0 ? (float) getenv(INTERVAL) : 13,
+        getenv(WAIT_FOR_CHECK) != "",
         ...$shas,
     )->then(function (string $state) use($logger) {
         $logger->info('Final status: ' . $state);


### PR DESCRIPTION
Hi,

I was looking into this action for use in a CD setup on NixOS and [Hydra](https://github.com/NixOS/hydra). Hydra may take a minute or two to send the first pending checks update to GitHub. By that time the action has already given up and allowed the deployment to continue.

This PR adds an additional option to this action, which will wait for all checks being completed (with at least one started)

PS: Currently the mutation testing CI step fails. I am not a PHP programmer so I am unsure what kind of additional test cases would be needed. I also haven’t gotten infection working so I cannot test locally and get more than just “Improve your test suite”